### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,13 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental": "^5.0",
-        "dynamic/silverstripe-geocoder": "^3.0",
-        "silverstripe/framework": "^5.0"
+        "php": "^8.1",
+        "dnadesign/silverstripe-elemental": "^6.0",
+        "dynamic/silverstripe-geocoder": "^4.0",
+        "silverstripe/framework": "^6.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^6"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/composer.json
+++ b/composer.json
@@ -26,13 +26,13 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "dnadesign/silverstripe-elemental": "^6.0",
         "dynamic/silverstripe-geocoder": "^4.0",
         "silverstripe/framework": "^6.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^6"
+        "silverstripe/recipe-testing": "^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Upgrades the module to SilverStripe 6 compatibility.

## Changes

- Updated PHP requirement to ^8.3 (SS6 requires PHP 8.3+)
- Updated dnadesign/silverstripe-elemental: ^5 → ^6
- Updated dynamic/silverstripe-geocoder: ^3 → ^4
- Updated silverstripe/framework: ^5 → ^6
- Updated silverstripe/recipe-testing: ^3 → ^4
- All tests passing (2/2)

This prepares the module for the v4.0.0 release.