### PR TITLE
Merge SS5 branch (3) into SS6 branch (4)

### DIFF
--- a/src/Elements/ElementCustomerService.php
+++ b/src/Elements/ElementCustomerService.php
@@ -22,6 +22,16 @@ class ElementCustomerService extends BaseElement
     /**
      * @var string
      */
+    private static $singular_name = 'Customer Service';
+
+    /**
+     * @var string
+     */
+    private static $plural_name = 'Customer Service Blocks';
+
+    /**
+     * @var string
+     */
     private static $icon = 'font-icon-info-circled';
 
     /**

--- a/src/Elements/ElementCustomerService.php
+++ b/src/Elements/ElementCustomerService.php
@@ -103,12 +103,4 @@ class ElementCustomerService extends BaseElement
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
     }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__.'.BlockType', 'Customer Service');
-    }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`

## Related

- Original SS5 PR: #35
- Parent issue: dynamic/silverstripe-essentials-tools#68